### PR TITLE
test: Fix 6 flaky tests

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -90,20 +92,24 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     List<InputRowListPlusRawValues> sampledAsBinary = sampleAllRows(readerNotAsString);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
-
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(
-        expectedJsonBinary,
-        DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())
-    );
+    
+    final String serializedJsonBinary = DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues());
+    JsonNode expectedBinary = objectMapper.readTree(expectedJsonBinary);
+    JsonNode serializedBinary = objectMapper.readTree(serializedJsonBinary);
+    Assert.assertTrue(expectedBinary.equals(serializedBinary));
   }
 
 
@@ -140,10 +146,14 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
   @Test
@@ -246,6 +256,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"enumColumn\" : \"SPADES\",\n"
                                 + "  \"maybeStringColumn\" : null,\n"
@@ -305,7 +316,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
   @Test
@@ -339,10 +353,14 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
 
@@ -378,6 +396,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"primitive\" : 2,\n"
                                 + "  \"myComplex\" : [ {\n"
@@ -385,7 +404,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
   @Test
@@ -425,6 +447,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"optionalMessage\" : null,\n"
                                 + "  \"requiredPrimitive\" : 9,\n"
@@ -435,6 +458,9 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 }


### PR DESCRIPTION
### Description

Fixed 6 flaky tests by using `JsonNode.equals` function, instead of comparing raw strings.


### Key changed/added classes in this PR
 * `CompatParquetReaderTest`

### Root Cause
The original tests tried to compare a hard-coded JSON string with another string dynamically generated from a JSON object. Since the serialized JSON string is generated with an indeterminate order in keys, these 6 tests are thus flaky.

### Fix 
All the JSON strings are converted to `JsonNode`. Now the method `JsonNode.equals` is order-insensitive, the problem is solved.

### How to reproduce the test
**Java version**: 11.0.20.1
**Maven version**: 3.6.3

1. Build the module
```
mvn install -pl extensions-core/parquet-extensions -am -DskipTests
```

2. Test without shuffling
```
mvn -pl extensions-core/parquet-extensions test -Dtest=org.apache.druid.data.input.parquet.CompatParquetReaderTest#testParquetThriftCompat
```
This test passed.

3. Test with shuffling using [NonDex](https://github.com/TestingResearchIllinois/NonDex)
```
mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.CompatParquetReaderTest#testParquetThriftCompat
```
This test passed with the proposed fix but failed without it.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

